### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/rigtorp/go-pikchr
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.7
+require github.com/tetratelabs/wazero v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
-github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
-github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/pikchr.go
+++ b/pikchr.go
@@ -23,20 +23,12 @@ func Render(in io.Reader, out io.Writer) error {
 
 	wasi_snapshot_preview1.MustInstantiate(ctx, r)
 
-	code, err := r.CompileModule(ctx, pikchrWasm)
-	if err != nil {
-		return err
-	}
-
 	// Only stdin and stdout is exposed to the WASM module
 	config := wazero.NewModuleConfig().WithStdout(out).WithStdin(in).WithArgs("pikchr", "--svg-only", "-")
 
-	_, err = r.InstantiateModule(ctx, code, config)
-	if err != nil {
-		return err
-	}
+	_, err := r.InstantiateWithConfig(ctx, pikchrWasm, config)
 
-	return nil
+	return err
 }
 
 // RenderString converts input Pikchr figure into output SVG figure.


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!